### PR TITLE
Add new hsv based palette color scheme

### DIFF
--- a/app/game.rb
+++ b/app/game.rb
@@ -28,10 +28,11 @@ PLAYER_ELEVATION = 0
 BOOST_AMOUNT = 10
 
 def player!(opts={})
+  r, g, b = hsv_to_rgb rand(360), 1, 1
   {
     x: 0, y: 0,
     w: 0, h: 0,
-    r: rand(230), g: rand(215), b: rand(255),
+    r: r, g: g, b: b,
 
     vertical: false,
 
@@ -276,6 +277,24 @@ def play_kick_sound
     input: 'sounds/GameStart.wav',
     pitch: 0.2,
   }
+end
+
+def hsv_to_rgb h, s, v
+  # based on conversion listed here: https://www.rapidtables.com/convert/color/hsv-to-rgb.html
+  c = v * s
+  x = c * (1 - ((h / 60) % 2 - 1).abs)
+  m = v - c
+
+  rp, gp, bp = [
+    [c, x, 0], #   0 < h <  60
+    [x, c, 0], #  60 < h < 120
+    [0, c, x], # 120 < h < 180
+    [0, x, c], # 180 < h < 240
+    [x, 0, c], # 240 < h < 300
+    [c, 0, x]  # 300 < h < 360
+  ][h / 60]
+
+  return [rp, gp, bp].map { | p | 255 * (p + m) }
 end
 
 init

--- a/app/game.rb
+++ b/app/game.rb
@@ -28,11 +28,16 @@ PLAYER_ELEVATION = 0
 BOOST_AMOUNT = 10
 
 def player!(opts={})
-  r, g, b = hsv_to_rgb rand(360), 1, 1
+  if opts.has_key? :color
+    color = opts[:color]
+  else
+    r, g, b = hsv_to_rgb rand(360), 1, 1
+    color = { r: r, g: g, b: b }
+  end
+  palette = generate_palette_5
   {
     x: 0, y: 0,
     w: 0, h: 0,
-    r: r, g: g, b: b,
 
     vertical: false,
 
@@ -40,7 +45,7 @@ def player!(opts={})
     dv: ACCELERATION_NORMAL,
 
     score: 10,
-  }.merge! opts
+  }.merge(color).merge! opts
 end
 
 def ball!(opts={})
@@ -64,16 +69,19 @@ end
 init {
   play_start_sound
 
+  palette = generate_palette_5
+  bg_color = palette[4]
+
   $state.background = [
     0, 0, grid.w, grid.h,
-    rand(180), rand(180), rand(200)
+    bg_color.r, bg_color.g, bg_color.b
   ]
 
   $state.players = {
-    top:    player!(y: grid.h-PLAYER_HEIGHT-PLAYER_ELEVATION, w: grid.w, h: PLAYER_HEIGHT),
-    right:  player!(x: grid.w-PLAYER_HEIGHT-PLAYER_ELEVATION, w: PLAYER_HEIGHT, h: grid.h, vertical: true),
-    bottom: player!(y: PLAYER_ELEVATION, h: PLAYER_HEIGHT),
-    left:   player!(x: PLAYER_ELEVATION, w: PLAYER_HEIGHT, h: grid.h, vertical: true),
+    top:    player!(y: grid.h-PLAYER_HEIGHT-PLAYER_ELEVATION, w: grid.w, h: PLAYER_HEIGHT, color: palette[0]),
+    right:  player!(x: grid.w-PLAYER_HEIGHT-PLAYER_ELEVATION, w: PLAYER_HEIGHT, h: grid.h, vertical: true, color: palette[1]),
+    bottom: player!(y: PLAYER_ELEVATION, h: PLAYER_HEIGHT, color: palette[2]),
+    left:   player!(x: PLAYER_ELEVATION, w: PLAYER_HEIGHT, h: grid.h, vertical: true, color: palette[3]),
   }
 
   $state.players.each { |(position, player)|
@@ -279,8 +287,34 @@ def play_kick_sound
   }
 end
 
+def generate_palette_5
+  # this generates a five color palette for paddles and the background
+  offset = rand(45) + 90
+
+  h_p0 = rand(360)
+  h_p2 = h_p0 + 180
+
+  h_p1 = h_p2 + offset
+  h_p3 = h_p2 - offset
+
+  palette_hsv = [
+    [h_p0, 1, 1],
+    [h_p1, 1, 1],
+    [h_p2, 1, 1],
+    [h_p3, 1, 1],
+    [h_p0, 0.7 * rand, 0.3 * rand]
+  ]
+
+  palette_hsv.map do |hsv|
+    r, g, b = hsv_to_rgb *hsv
+    { r: r, g: g, b: b }
+  end
+end
+
 def hsv_to_rgb h, s, v
   # based on conversion listed here: https://www.rapidtables.com/convert/color/hsv-to-rgb.html
+  h = h % 360
+
   c = v * s
   x = c * (1 - ((h / 60) % 2 - 1).abs)
   m = v - c


### PR DESCRIPTION
![color_schemes](https://user-images.githubusercontent.com/615889/123954048-ee755500-d975-11eb-9f37-4fd8aa2cfc8f.gif)

(sorry, dunno why the gif has weird color issues)

implements an HSV -> RGB conversion based on https://www.rapidtables.com/convert/color/hsv-to-rgb.html
HSV is preferred for this case since one of the requirements is to have "vibrant" colors for the player.

the basic color scheme is the following:

 - all players have full saturation and value
 - top and bottom players have complementary (opposite hue) colors
 - left and right are offset from the top player by a random value
 - between 45 and 135 degrees
 - background color is set to be the top player's hue with random
   saturation and value values between 0.7 and 0.3 respectively

as a future extension, additional randomness can be added by introducing a few more palette
schemes and randomly choosing between those.