### PR TITLE
narrow range of background color so you can see black balls

### DIFF
--- a/app/game.rb
+++ b/app/game.rb
@@ -329,7 +329,7 @@ def generate_palette_5
     [h_p1, 1, 1],
     [h_p2, 1, 1],
     [h_p3, 1, 1],
-    [h_p0, 0.7 * rand, 0.3 * rand]
+    [h_p0, 0.7 * rand, 0.2 * rand + 0.1]
   ]
 
   palette_hsv.map do |hsv|


### PR DESCRIPTION
the black balls were very difficult to see with cases where the
background color was using a particularly low value. this PR narrows
that range a touch from [0-0.3] to [0.1-0.3] so that very low
visibility colors are not selected.